### PR TITLE
Fixing circular dependency warning (#4)

### DIFF
--- a/src/Graphemer.ts
+++ b/src/Graphemer.ts
@@ -77,7 +77,7 @@ export default class Graphemer {
    * @returns {GraphemerIterator}
    */
   iterateGraphemes(str: string): GraphemerIterator {
-    return new GraphemerIterator(str);
+    return new GraphemerIterator(str, Graphemer.nextBreak);
   }
 
   /**

--- a/src/GraphemerIterator.ts
+++ b/src/GraphemerIterator.ts
@@ -1,5 +1,3 @@
-import Graphemer from './Graphemer';
-
 /**
  * GraphemerIterator
  *
@@ -12,9 +10,11 @@ import Graphemer from './Graphemer';
 class GraphemerIterator implements Iterator<string> {
   private _index: number = 0;
   private _str: string;
+  private _nextBreak: (str: string, index: number) => number;
 
-  constructor(str: string) {
+  constructor(str: string, nextBreak: (str: string, index: number) => number) {
     this._str = str;
+    this._nextBreak = nextBreak;
   }
 
   [Symbol.iterator]() {
@@ -23,9 +23,7 @@ class GraphemerIterator implements Iterator<string> {
 
   next() {
     let brk;
-    if (
-      (brk = Graphemer.nextBreak(this._str, this._index)) < this._str.length
-    ) {
+    if ((brk = this._nextBreak(this._str, this._index)) < this._str.length) {
       const value = this._str.slice(this._index, brk);
       this._index = brk;
       return { value: value, done: false };


### PR DESCRIPTION
Resolves #4 

Instead of using `nextBreak` from the imported `Graphmer` this PR injects `nextBreak` into `GraphmerIterator`